### PR TITLE
controller now downloads results to storage after each repeat using scp

### DIFF
--- a/cli/localhost_config.toml
+++ b/cli/localhost_config.toml
@@ -1,0 +1,18 @@
+[[hosts]]
+name = "runner1"
+address = "localhost"
+infrastructure = "linux"
+
+[[exporters]]
+name = "test-exporter"
+hosts = ["runner1"]
+# this should not run for a fixed run time, it should be ended when the experiment is ended
+# this is just for testing results collection
+command = "sar -o sar_output.bin 1 10"
+setup = ["dnf install -y sysstat", "apt install -y sysstat"]
+kind = "node"
+[[exporters]]
+name = "another-test-exporter"
+hosts = ["runner1"]
+command = "my_collector"
+kind = "node"

--- a/cli/localhost_experiment_config.toml
+++ b/cli/localhost_experiment_config.toml
@@ -1,0 +1,38 @@
+name = "localhost-experiment"
+description = "Testing the functionality of the software completely using localhost"
+kind = "localhost-result"
+execute = "./scripts/actual-work.sh"
+arguments = ["Argument 1", "Argument 2"]
+# Optional, not checked if omitted
+# If you need to override on a per-variation basis, omit the top-level definition,
+# and instead add it to the individual variation.
+expected_arguments = 2
+hosts = ["runner1"]
+# Optional, defaults to 1
+runs = 1
+
+[[setup]]
+hosts = ["runner1"]
+scripts = ["./scripts/test-setup.sh"]
+
+#[[variations]]
+# This empty variation will inherit all the top-level fields
+#[[variations]]
+#name = "different args"
+#arguments = ["Argument 1"]
+#expected_arguments = 1
+
+[[variations]]
+name = "with-exporter"
+exporters = ["test-exporter"]
+
+[[variations]]
+name = "other"
+
+#[[variations]]
+#name = "with multiple exporters"
+#exporters = ["test-exporter", "another-test-exporter"]
+
+[[teardown]]
+hosts = ["runner1"]
+scripts = ["./scripts/test-teardown.sh"]

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -1,4 +1,7 @@
-use std::time::{Duration, SystemTime, SystemTimeError, UNIX_EPOCH};
+use std::{
+    path::Path,
+    time::{Duration, SystemTime, SystemTimeError, UNIX_EPOCH},
+};
 
 pub mod db;
 pub mod parse;
@@ -59,4 +62,35 @@ pub const DATABASE_NAME: &str = "experimentah";
 
 fn time_since_epoch() -> Result<Duration, SystemTimeError> {
     SystemTime::now().duration_since(UNIX_EPOCH)
+}
+
+/// This function converts a path of format:
+/// <PREFIX>/<TIMESTAMP>/<RUN>/<NAME> into
+/// (<NAME>, <RUN>, <TIMESTAMP>)
+fn variation_dir_parts(variation_directory: &Path) -> (String, u16, u128) {
+    let experiment_name = variation_directory
+        .file_name()
+        .expect("Variation directory did not contain an experiment name")
+        .to_string_lossy()
+        .to_string();
+    let run: u16 = variation_directory
+        .parent()
+        .unwrap()
+        .file_name()
+        .expect("Variation directory did not contain a run number")
+        .to_string_lossy()
+        .parse()
+        .expect("Run number was not a valid u16");
+    let ts = variation_directory
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .file_name()
+        .expect("Variation directory did not contain a timestamp")
+        .to_string_lossy()
+        .parse()
+        .expect("Timestamp was not a valid u128 (milliseconds)");
+
+    (experiment_name, run, ts)
 }

--- a/controller/src/ssh.rs
+++ b/controller/src/ssh.rs
@@ -290,7 +290,8 @@ pub async fn download(
         .map(|p| p.to_string_lossy().to_string())
         .collect();
     let params = (remote_args, local_destination.to_path_buf());
-    common_async(sessions, do_scp_download, params).await
+    common_async(sessions, do_scp_download, params).await?;
+    Ok(())
 }
 
 // TODO(jackson): maybe just make the do_scp function work for upload and download?
@@ -321,8 +322,10 @@ async fn do_scp_download(
     if !output.status.success() {
         let status_code = output.status.code();
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        let msg = format!("Failed to scp download from host {host} -> {}",
-            local_destination_dir.to_string_lossy());
+        let msg = format!(
+            "Failed to scp download from host {host} -> {}",
+            local_destination_dir.to_string_lossy()
+        );
         Err((msg, stderr, status_code))?;
     }
 


### PR DESCRIPTION
Jackson added a config file to help with testing in localhost settings, which should be pretty useful on the CLI end of things.

Collecting results currently follows the same format as the upload function, but it might be worth changing it so that it is able to retrieve results from all remote hosts simultaneously.