### PR TITLE
Adding the ability to follow the logs of any executed command.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
  "axum-core",
  "axum-macros",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -138,8 +139,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -203,6 +206,15 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -314,6 +326,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shlex",
+ "strum",
  "tokio",
  "toml",
  "tower",
@@ -336,6 +349,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
 name = "derive_destructure2"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +382,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -546,6 +594,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1319,6 +1377,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,6 +1408,35 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1628,6 +1724,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shell-escape"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,6 +1814,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -1875,6 +2003,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,6 +2152,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicase"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2039,6 +2202,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -2415,6 +2584,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -11,7 +11,7 @@ serde = { workspace = true }
 # reqwest = { workspace = true }
 tokio = { workspace = true }
 shlex = "=1.3.0"
-axum = {version = "0.8", features = ["multipart", "macros"]}
+axum = {version = "0.8", features = ["multipart", "macros", "ws"]}
 env_logger = "0.11.8"
 log = "0.4.27"
 tower = "0.5.2"
@@ -22,3 +22,5 @@ openssh = "0.11.5"
 openssh-sftp-client = { version = "0.15.2", features = ["openssh"] }
 rusqlite = { version = "0.37.0", features = ["bundled"]}
 regex = "1.11.2"
+strum = {version = "0.27.2", features = ["derive"]}
+

--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -37,10 +37,6 @@ pub mod session;
 /// - storage/DATABASE
 pub const DEFAULT_STORAGE_DIR: &str = "storage";
 
-/// A list of important subdirectories for remote/local hosts.
-pub const SUBDIRECTORIES: [&str; 4] =
-    ["setup", "execute", "teardown", "exporters"];
-
 /// We want all our remote operations to occur in a well-known directory, so that we can avoid.
 ///
 /// Overwriting anything that's pre-existing on the target system.

--- a/controller/src/main.rs
+++ b/controller/src/main.rs
@@ -1,7 +1,7 @@
 use std::{env, sync::Arc};
 
 use axum::{
-    routing::{get, post},
+    routing::{any, get, post},
     Router,
 };
 
@@ -46,5 +46,6 @@ fn router(run_state: RunState) -> Router {
         .route("/status", get(routes::status))
         .route("/run", post(routes::run))
         .route("/upload", post(routes::upload))
+        .route("/ws", any(routes::ws_handler))
         .with_state(run_state)
 }

--- a/controller/src/parse.rs
+++ b/controller/src/parse.rs
@@ -931,21 +931,13 @@ fn arguments_check_lax(
     expected_arguments: Option<usize>,
     arguments: Option<&Vec<String>>,
 ) -> Result<()> {
-    match (expected_arguments, arguments) {
-        // (Some(expected), None) => {
-        //     if expected != 0 {
-        //         Err(Error::ValidationError("expected_arguments should be set to 0 if arguments is unset".to_string()))?;
-        //     }
-        // }
-        (Some(expected), Some(arguments)) => {
-            if expected != arguments.len() {
-                Err(Error::ValidationError(format!(
-                    "Expected {expected} arguments, got {}",
-                    arguments.len()
-                )))?;
-            }
+    if let (Some(expected), Some(arguments)) = (expected_arguments, arguments) {
+        if expected != arguments.len() {
+            Err(Error::ValidationError(format!(
+                "Expected {expected} arguments, got {}",
+                arguments.len()
+            )))?;
         }
-        _ => {}
     }
 
     Ok(())
@@ -1779,7 +1771,7 @@ impl Display for RemoteExecution {
 }
 
 /// Describes the significance of a file for remote use.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, strum::EnumIter)]
 pub enum FileType {
     /// Setup files are used during the setup stage of an experiment.
     Setup,

--- a/controller/src/run.rs
+++ b/controller/src/run.rs
@@ -1,12 +1,13 @@
 //! Functionality for queueing and running experiments.
 
 use crate::parse::{
-    CommandSource, Experiment, ExperimentRuns, Exporter, Host, RemoteExecution,
+    CommandSource, Experiment, ExperimentRuns, Exporter, FileType, Host,
+    RemoteExecution,
 };
 use crate::{
     command, file_to_deps_path, time_since_epoch, variation_dir_parts,
     DEFAULT_LIVE_DIR, DEFAULT_REMOTE_DIR, DEFAULT_RESULTS_DIR,
-    DEFAULT_STORAGE_DIR, SUBDIRECTORIES,
+    DEFAULT_STORAGE_DIR,
 };
 
 /// Internally I've just set the queue to begin with a capacity of 32 potential [`ExperimentRuns`].
@@ -21,13 +22,18 @@ const DEFAULT_POLL_SLEEP: Duration = Duration::from_millis(250);
 
 static KILL_EXPORTERS: AtomicBool = AtomicBool::new(false);
 
+use axum::extract::ws::Message;
 use log::{debug, error, info};
 use std::collections::{HashMap, VecDeque};
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::Mutex;
+use strum::IntoEnumIterator;
+use tokio::io::AsyncReadExt;
+use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::{Mutex, RwLock};
 use tokio::task::JoinHandle;
 
 use crate::command::{ExecutionResult, ExecutionType, ShellCommand, SpawnType};
@@ -75,6 +81,7 @@ pub enum Error {
     Generic(String),
     JoinError(String, tokio::task::JoinError),
     OpenSSHError(String, openssh::Error),
+    FollowError(String),
 }
 
 impl std::fmt::Display for Error {
@@ -98,6 +105,9 @@ impl std::fmt::Display for Error {
             Error::Generic(ref message) => {
                 write!(f, "{message}")
             }
+            Error::FollowError(ref message) => {
+                write!(f, "{message}")
+            }
         }
     }
 }
@@ -111,6 +121,7 @@ impl std::error::Error for Error {
             Error::JoinError(.., ref source) => Some(source),
             Error::OpenSSHError(.., ref source) => Some(source),
             Error::Generic(..) => None,
+            Error::FollowError(..) => None,
         }
     }
 }
@@ -189,30 +200,6 @@ impl From<openssh::Error> for Error {
     }
 }
 
-/// The [`ExperimentRunner`] needs a queue for receiving and running experiments.
-/// This type contains that queue, which is within a mutex for internal mutability.
-pub type ExperimentQueue = Mutex<VecDeque<ExperimentRuns>>;
-
-/// An [`ExperimentRunner`] provides the main functionality of Experimentah. It has a queue along
-/// with multiple metrics for inspecting the current state of the controller.
-pub struct ExperimentRunner {
-    /// When an experiment is running, this contains the name of the experiment
-    pub current_experiment: Mutex<Option<String>>,
-    /// When an experiment is running, this contains the total number of runs that the experiment
-    /// will be repeated for.
-    pub current_runs: AtomicU16,
-    /// When an experiment is running, this contains the current run number that the experiment is
-    /// up to.
-    pub current_run: AtomicU16,
-    /// The queue containing experiments sent in from clients.
-    pub experiment_queue: ExperimentQueue,
-    /// A configuration which mainly contains important file paths for storing
-    /// experiment/controller information.
-    pub configuration: ExperimentRunnerConfiguration,
-    /// Contains a list of the running exporters for the current experiment
-    live_exporters: Mutex<ExportersHandles>,
-}
-
 /// The [`ExperimentRunner`] requires a great deal of configuration options (paths, etc) which it
 /// must maintain a reference to. These fields are stored in this configuration struct.
 pub struct ExperimentRunnerConfiguration {
@@ -237,6 +224,21 @@ pub struct ExperimentRunnerConfiguration {
     pub live_dir: PathBuf,
 }
 
+impl ExperimentRunnerConfiguration {
+    /// Returns directories that need to be created for experiments to run correctly
+    fn directories(&self) -> Vec<PathBuf> {
+        FileType::iter().map(|ft| self.live_dir(&ft)).collect()
+    }
+
+    // TODO(joren): live_dir almost definitely needs to be changed so that it makes use of the
+    // FileType enum. That way we don't have floating magical funny strings around the place.
+    fn live_dir(&self, filetype: &FileType) -> PathBuf {
+        self.experimentation_dir
+            .join(&self.live_dir)
+            .join(filetype.to_string())
+    }
+}
+
 impl Default for ExperimentRunnerConfiguration {
     fn default() -> Self {
         Self {
@@ -250,46 +252,154 @@ impl Default for ExperimentRunnerConfiguration {
     }
 }
 
-impl ExperimentRunnerConfiguration {
-    /// Returns directories that need to be created for experiments to run correctly
-    fn directories(&self) -> Vec<PathBuf> {
-        let mut directories = Vec::new();
+/// The [`ExperimentRunner`] needs a queue for receiving and running experiments.
+/// This type contains that queue, which is within a mutex for internal mutability.
+pub type ExperimentQueue = VecDeque<ExperimentRuns>;
 
-        for directory in SUBDIRECTORIES {
-            directories.push(
-                self.experimentation_dir
-                    .join(&self.live_dir)
-                    .join(directory),
-            );
-        }
-        directories
+/// Stores important information inside an [`ExperimentRunner`] that is expected to clear at the
+/// end of a variation and change during a run.
+#[derive(Default)]
+pub struct ExperimentRunnerCurrent {
+    /// When an experiment is running, this contains the name of the experiment
+    pub experiment_name: Arc<Mutex<Option<String>>>,
+    /// The timestamp (in milliseconds) when the current experiment started running.
+    /// Note that this timestamp is not per-variation.
+    pub ts: Arc<Mutex<u128>>,
+    /// When an experiment is running, this contains the total number of runs that the experiment
+    /// will be repeated for.
+    pub runs: AtomicU16,
+    /// When an experiment is running, this contains the current run number that the experiment is
+    /// up to.
+    pub run: AtomicU16,
+
+    /// Contains a mapping from hosts to Sessions (for running commands) for the current
+    /// experiment.
+    pub sessions: Arc<RwLock<Sessions>>,
+    /// Contains a list of the running exporters for the current experiment.
+    pub exporters: Arc<RwLock<ExportersHandles>>,
+    // pub experiment_directory: Arc<Mutex<PathBuf>>,
+}
+
+impl ExperimentRunnerCurrent {
+    async fn reset(&self) {
+        *self.experiment_name.lock().await = None;
+        *self.ts.lock().await = 0;
+        self.runs.store(0, Ordering::Relaxed);
+        self.run.store(0, Ordering::Relaxed);
+        self.exporters.write().await.clear();
+        self.sessions.write().await.clear();
     }
 
-    fn live_dir(&self, subdir: &str) -> PathBuf {
-        self.experimentation_dir.join(&self.live_dir).join(subdir)
+    async fn set_experiment_name(&self, experiment: &Experiment) {
+        *self.experiment_name.lock().await = Some(experiment.name.clone());
+    }
+
+    pub async fn status(&self) -> String {
+        let experiment_name = self.experiment_name.lock().await;
+        let run = self.run.load(Ordering::Relaxed);
+        let runs = self.runs.load(Ordering::Relaxed);
+        let sessions = self.sessions.read().await;
+        let exporters = self.exporters.read().await;
+
+        let experiment_name =
+            if let Some(experiment_name) = experiment_name.as_ref() {
+                experiment_name
+            } else {
+                &"None".to_string()
+            };
+
+        format!("experiment_name: {}, {run}/{runs} runs, {} unique hosts, {} exporters spawned", experiment_name, sessions.len(), exporters.len())
+    }
+
+    pub async fn experiment_directory(
+        &self,
+        experimentation_directory: &Path,
+    ) -> PathBuf {
+        let ts = self.ts.lock().await;
+        assert!(
+            *ts != 0,
+            "This function can't be used until the timestamp has been set"
+        );
+
+        PathBuf::from(format!("{}/{}", experimentation_directory.display(), ts))
+    }
+
+    pub async fn repeat_directory(
+        &self,
+        experimentation_directory: &Path,
+    ) -> PathBuf {
+        let run = self.run.load(Ordering::Relaxed);
+        assert!(run > 0);
+
+        self.experiment_directory(experimentation_directory)
+            .await
+            .join(run.to_string())
+    }
+
+    pub async fn variation_directory(
+        &self,
+        experimentation_directory: &Path,
+    ) -> PathBuf {
+        let experiment_name = self.experiment_name.lock().await;
+        let experiment_name = experiment_name.as_ref().expect("This function should only be called once the experiment name has been set!");
+
+        self.repeat_directory(experimentation_directory)
+            .await
+            .join(experiment_name)
     }
 }
 
-impl Default for ExperimentRunner {
-    fn default() -> Self {
-        let configuration: ExperimentRunnerConfiguration = Default::default();
-
-        Self {
-            experiment_queue: Mutex::new(VecDeque::with_capacity(
-                configuration.max_experiments,
-            )),
-            configuration,
-            current_runs: Default::default(),
-            current_experiment: Default::default(),
-            current_run: Default::default(),
-            live_exporters: Default::default(),
-        }
-    }
+/// An [`ExperimentRunner`] provides the main functionality of Experimentah. It has a queue along
+/// with multiple metrics for inspecting the current state of the controller.
+pub struct ExperimentRunner {
+    /// Contains variables that relevant only to the current experiment being run.
+    /// These variables need to accessible from outside the experiment runner (for API
+    /// endpoints to view them).
+    pub current: ExperimentRunnerCurrent,
+    /// A configuration which mainly contains important file paths for storing
+    /// experiment/controller information.
+    pub configuration: ExperimentRunnerConfiguration,
+    /// The queue containing experiments sent in from clients.
+    pub experiment_queue: Mutex<ExperimentQueue>,
+    // pub current: ExperimentRunnerCurrent,
+    // /// When an experiment is running, this contains the name of the experiment
+    // pub current_experiment: Mutex<Option<String>>,
+    // /// When an experiment is running, this contains the total number of runs that the experiment
+    // /// will be repeated for.
+    // pub current_runs: AtomicU16,
+    // /// When an experiment is running, this contains the current run number that the experiment is
+    // /// up to.
+    // pub current_run: AtomicU16,
+    // /// The queue containing experiments sent in from clients.
+    // pub experiment_queue: ExperimentQueue,
+    // /// A configuration which mainly contains important file paths for storing
+    // /// experiment/controller information.
+    // pub configuration: ExperimentRunnerConfiguration,
+    // /// Contains a list of the running exporters for the current experiment
+    // live_exporters: Mutex<ExportersHandles>,
 }
 
 impl ExperimentRunner {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub async fn experiment_directory(&self) -> PathBuf {
+        self.current
+            .experiment_directory(&self.configuration.experimentation_dir)
+            .await
+    }
+
+    pub async fn repeat_directory(&self) -> PathBuf {
+        self.current
+            .repeat_directory(&self.configuration.experimentation_dir)
+            .await
+    }
+
+    pub async fn variation_directory(&self) -> PathBuf {
+        self.current
+            .variation_directory(&self.configuration.experimentation_dir)
+            .await
     }
 
     /// Add a new experiment to the runner
@@ -302,34 +412,14 @@ impl ExperimentRunner {
             let mut queue = self.experiment_queue.lock().await;
             match queue.pop_front() {
                 Some(experiment_runs) => {
-                    self.current_runs
+                    self.current
+                        .runs
                         .store(experiment_runs.0, Ordering::Relaxed);
                     return experiment_runs;
                 }
                 None => tokio::time::sleep(self.configuration.poll_sleep).await,
             }
         }
-    }
-
-    async fn reset_metadata(&self) {
-        self.current_runs.store(0, Ordering::Relaxed);
-        self.current_run.store(0, Ordering::Relaxed);
-        *self.current_experiment.lock().await = None;
-    }
-
-    async fn update_current_experiment(
-        &self,
-        experiment: &Experiment,
-        run: u16,
-    ) {
-        info!(
-            "Running experiment '{}' (repeat {}/{})...",
-            &experiment.name,
-            run,
-            self.current_runs.load(Ordering::Relaxed)
-        );
-        let mut current_experiment = self.current_experiment.lock().await;
-        *current_experiment = Some(experiment.name.clone());
     }
 
     // I really have no idea what I want to do for the ExperimentRunner main loop.
@@ -362,7 +452,7 @@ impl ExperimentRunner {
             let (runs, experiments) = self.wait_for_experiments().await;
 
             // We create the timestamp once for each full experiment
-            let ts = time_since_epoch()?.as_millis();
+            *self.current.ts.lock().await = time_since_epoch()?.as_millis();
 
             info!(
                 "Experiment with {} variations received ({} repeats).",
@@ -370,20 +460,11 @@ impl ExperimentRunner {
                 runs
             );
 
-            let hosts = Self::unique_hosts_for_all_experiments(&experiments);
-            let sessions = session::connect_to_hosts(&hosts).await?;
-
-            let experiment_directory = PathBuf::from(format!(
-                "{}/{ts}",
-                self.configuration.experimentation_dir.display()
-            ));
+            // Generate the sessions we need by connecting to hosts
+            self.connect_to_hosts(&experiments).await?;
 
             // Ensure that our 'well-known' directories are present
-            session::make_directories(
-                &sessions,
-                &self.configuration.directories(),
-            )
-            .await?;
+            self.make_configuration_directories().await?;
 
             // TODO(joren): All important files need to be uploaded to the correct
             // directory on all the remote sessions ahead of the actual experiment runs.
@@ -391,62 +472,43 @@ impl ExperimentRunner {
             // /srv/experimentah/<timestamp>/<repeat_no>/ directory, we want all
             // resources for that specific experiment to instead populate the
             // /srv/experimentah/<timestamp>/ directory.
-            let files = Self::unique_files_for_all_experiments(&experiments);
-            session::upload(&sessions, &files, &experiment_directory).await?;
+            self.upload_files_for_experiments(&experiments).await?;
 
             // TODO(joren): For dependencies, the current solution is to upload them normally, and
             // then adjust them afterwards to be in the correct subdirectory. It's definitely dumb
             // to do it this way but it's the path of least resistance at the moment.
-            Self::correct_dependencies(
-                &sessions,
-                &experiments,
-                &experiment_directory,
-            )
-            .await?;
+            self.correct_dependencies(&experiments).await?;
 
             for run in 1..=runs {
-                self.current_run.store(run, Ordering::Relaxed);
-
-                let repeat_directory: &Path =
-                    &experiment_directory.join(run.to_string());
+                self.current.run.store(run, Ordering::Relaxed);
 
                 for experiment in experiments.iter() {
-                    let variation_directory: &Path =
-                        &repeat_directory.join(&experiment.name);
+                    self.current.set_experiment_name(experiment).await;
 
-                    self.update_current_experiment(experiment, run).await;
-                    session::make_directory(&sessions, variation_directory)
-                        .await?;
+                    // Create the variation_directory
+                    self.make_variation_directory().await?;
+
+                    info!(
+                        "Running experiment '{}' (repeat {}/{})...",
+                        &experiment.name,
+                        run,
+                        self.current.runs.load(Ordering::Relaxed)
+                    );
 
                     // Here we symlink our script dependencies within the current repeat directory
-                    Self::symlink_dependencies(
-                        &sessions,
+                    self.symlink_dependencies(
                         &experiment.execute,
                         &experiment.dependencies,
-                        &experiment_directory,
-                        variation_directory,
                     )
                     .await?;
+
                     debug!(
                         "Symlinked dependencies for '{:?}': {:?}",
                         &experiment.execute, &experiment.dependencies
                     );
 
-                    let exporters = Self::start_exporters(
-                        &sessions,
-                        &experiment.exporters,
-                        &self.configuration.live_dir("exporters"),
-                        variation_directory,
-                    )
-                    .await?;
-
-                    {
-                        let mut live_exporters =
-                            self.live_exporters.lock().await;
-                        *live_exporters = exporters;
-                    }
+                    self.start_exporters(&experiment.exporters).await?;
                     info!("Started exporters");
-                    tokio::time::sleep(Duration::from_secs(5)).await;
 
                     // TODO(joren): We want to make sure that our setup/teardown
                     // is run from the *variation* directory, and not the experiment
@@ -456,56 +518,35 @@ impl ExperimentRunner {
                     //
                     // Therefore this function needs to change it's responsibilities
 
-                    Self::run_remote_executions(
-                        &sessions,
-                        &experiment.setups,
-                        &experiment_directory,
-                        variation_directory,
-                    )
-                    .await?;
+                    self.run_remote_executions(&experiment.setups).await?;
                     info!("Variation setup complete");
 
-                    Self::run_remote_execution(
-                        &sessions,
-                        &experiment.execute,
-                        &experiment_directory,
-                        variation_directory,
-                    )
-                    .await?;
+                    self.run_remote_execution(&experiment.execute).await?;
                     info!("Variation complete");
 
-                    Self::run_remote_executions(
-                        &sessions,
-                        &experiment.teardowns,
-                        &experiment_directory,
-                        variation_directory,
-                    )
-                    .await?;
+                    self.run_remote_executions(&experiment.teardowns).await?;
                     info!("Variation teardown complete");
 
                     // Time for us to close our exporters
                     {
                         KILL_EXPORTERS.store(true, Ordering::Relaxed);
 
-                        let mut live_exporters =
-                            self.live_exporters.lock().await;
-                        for (_exporter_name, handles) in live_exporters.drain()
-                        {
+                        let mut exporters =
+                            self.current.exporters.write().await;
+                        for (_exporter_name, handles) in exporters.drain() {
                             for handle in handles {
                                 handle.await??;
                             }
                         }
 
-                        assert!(live_exporters.len() == 0);
+                        assert!(exporters.len() == 0);
                         KILL_EXPORTERS.store(false, Ordering::Relaxed);
                     }
                     info!("Stopped all exporters for variation");
 
-                    Self::unlink_dependencies(
-                        &sessions,
+                    self.unlink_dependencies(
                         &experiment.execute,
                         &experiment.dependencies,
-                        variation_directory,
                     )
                     .await?;
                     debug!("Unliked dependencies for variation");
@@ -515,26 +556,24 @@ impl ExperimentRunner {
                         .storage_dir
                         .join(&self.configuration.results_dir);
 
-                    Self::collect_results(
-                        &sessions,
-                        variation_directory,
-                        result_directory,
-                    )
-                    .await?;
+                    self.collect_results(result_directory).await?;
                     info!("Collected results for variation");
                 }
             }
-            info!("Finished experiments");
 
-            self.reset_metadata().await;
+            self.current.reset().await;
+            info!("Finished experiments");
         }
     }
 
     /// Since [`Sessions`] are just a mapping of host addresses to SSH sessions, this functions
     /// allows us to filter down a large mapping of [`Sessions`] to those that are important to our
     /// current scope.
-    fn filter_sessions(sessions: &Sessions, addresses: &[String]) -> Sessions {
-        sessions
+    async fn filter_sessions(&self, addresses: &[String]) -> Sessions {
+        self.current
+            .sessions
+            .read()
+            .await
             .iter()
             .filter(|(key, _)| addresses.contains(key))
             .map(|(key, value)| (key.clone(), value.clone()))
@@ -544,40 +583,25 @@ impl ExperimentRunner {
     /// This is the same as the [`filter_sessions`] function, except it takes advantage of the fact
     /// that many structs in Experimentah contain a list of [`Host`]s that we can filter on. Just a
     /// bit of syntactic sugar.
-    fn filter_host_sessions(sessions: &Sessions, hosts: &[Host]) -> Sessions {
+    async fn filter_host_sessions(&self, hosts: &[Host]) -> Sessions {
         let addresses: Vec<String> =
             hosts.iter().map(|host| &host.address).cloned().collect();
 
-        Self::filter_sessions(sessions, &addresses)
-    }
-
-    /// Retrieves all the unique hosts used across a list of experiments.
-    /// This is useful for performing pre-run and post-run actions on these
-    /// hosts that are necessary for experimentah to function correctly.
-    /// These hosts should be filtered as required by each individual experiment variation.
-    fn unique_hosts_for_all_experiments(
-        experiments: &[Experiment],
-    ) -> Vec<&String> {
-        let mut hosts: Vec<&String> = experiments
-            .iter()
-            .flat_map(|experiment| experiment.hosts())
-            .collect();
-
-        hosts.sort();
-        hosts.dedup();
-        hosts
+        self.filter_sessions(&addresses).await
     }
 
     // TODO(joren): This function shouldn't even exist.
     // We should make sure that we upload our dependencies into the correct directories from the
     // beginning of each experiment. This workaround doesn't make much sense.
     async fn correct_dependencies(
-        sessions: &Sessions,
+        &self,
         experiments: &[Experiment],
-        experiment_directory: &Path,
     ) -> Result<()> {
+        let sessions = &*self.current.sessions.read().await;
+
         for experiment in experiments.iter() {
             let execute = &experiment.execute;
+            let experiment_directory = self.experiment_directory().await;
 
             let execute_directory = match &execute.command {
                 CommandSource::Command(_) => experiment_directory.to_path_buf(),
@@ -618,32 +642,15 @@ impl ExperimentRunner {
         Ok(())
     }
 
-    /// Loops through a slice of experiments and returns
-    /// unique filepaths for that slice.
-    fn unique_files_for_all_experiments(
-        experiments: &[Experiment],
-    ) -> Vec<&Path> {
-        let mut files: Vec<&Path> = experiments
-            .iter()
-            .flat_map(|experiment| experiment.files())
-            .collect();
-
-        files.sort();
-        files.dedup();
-        files
-    }
-
-    async fn setup_exporters(
-        sessions: &Sessions,
-        exporters: &[Exporter],
-        variation_directory: &Path,
-    ) -> Result<()> {
+    async fn setup_exporters(&self, exporters: &[Exporter]) -> Result<()> {
         let mut futures: Vec<JoinHandle<Result<()>>> = Vec::new();
+
+        let variation_directory = self.variation_directory().await;
 
         let exporters_clone = exporters.to_vec();
         for exporter in exporters_clone.into_iter() {
             let exporter_sessions =
-                Self::filter_host_sessions(sessions, &exporter.hosts);
+                self.filter_host_sessions(&exporter.hosts).await;
             let variation_directory_clone = variation_directory.to_path_buf();
             // let exporter_clone = exporter.cloen()
             let exporter_clone = exporter.clone();
@@ -674,29 +681,27 @@ impl ExperimentRunner {
     /// Starts long-running exporters, which are expected to collect
     /// system-level metrics whilst an experiment is running.
     /// Think tools like 'sar' or 'ipmitool'
-    async fn start_exporters(
-        sessions: &Sessions,
-        exporters: &[Exporter],
-        exporter_dir: &Path,
-        variation_directory: &Path,
-    ) -> Result<ExportersHandles> {
+    async fn start_exporters(&self, exporters: &[Exporter]) -> Result<()> {
         let mut exporters_handles = ExportersHandles::new();
+
+        let variation_directory = self.variation_directory().await;
 
         // We now perform exporter setup in parallel, nice!
         // NOTE: each step of the setup for each exporter is still serial, as intended.
-        Self::setup_exporters(sessions, exporters, variation_directory).await?;
+        self.setup_exporters(exporters).await?;
 
         for exporter in exporters.iter() {
             let exporter_sessions =
-                Self::filter_host_sessions(sessions, &exporter.hosts);
+                self.filter_host_sessions(&exporter.hosts).await;
 
             let mut exporter_files = exporter.shell_files();
-            exporter_files.set_base(exporter_dir);
+            exporter_files
+                .set_base(self.configuration.live_dir(&FileType::Exporter));
 
             let mut shell_command =
                 ShellCommand::from_parsed_command(&exporter.command);
             shell_command
-                .working_directory(variation_directory)
+                .working_directory(&variation_directory)
                 .stdout_file(&exporter_files.stdout)
                 .stderr_file(&exporter_files.stderr)
                 .pid_file(&exporter_files.pid)
@@ -764,7 +769,9 @@ impl ExperimentRunner {
             exporters_handles.insert(exporter.name.clone(), handles);
         }
 
-        Ok(exporters_handles)
+        *self.current.exporters.write().await = exporters_handles;
+
+        Ok(())
     }
 
     //TODO(joren): We need remote commands to write their outputs to a file somewhere.
@@ -772,31 +779,25 @@ impl ExperimentRunner {
     //It's important to remember that we want to avoid streaming as much as possible
     //unless the client specifically requests it for debug purposes.
     async fn run_remote_executions(
-        sessions: &Sessions,
+        &self,
         remote_executions: &[RemoteExecution],
-        experiment_directory: &Path,
-        variation_directory: &Path,
     ) -> Result<()> {
         for remote_execution in remote_executions.iter() {
-            Self::run_remote_execution(
-                sessions,
-                remote_execution,
-                experiment_directory,
-                variation_directory,
-            )
-            .await?;
+            self.run_remote_execution(remote_execution).await?;
         }
         Ok(())
     }
 
     async fn run_remote_execution(
-        sessions: &Sessions,
+        &self,
         remote_execution: &RemoteExecution,
-        experiment_directory: &Path,
-        variation_directory: &Path,
     ) -> Result<()> {
         let setup_sessions =
-            Self::filter_host_sessions(sessions, &remote_execution.hosts);
+            self.filter_host_sessions(&remote_execution.hosts).await;
+
+        let experiment_directory = self.experiment_directory().await;
+        let variation_directory = self.variation_directory().await;
+
         for remote_script in remote_execution.remote_scripts().iter() {
             // This assertion only checks locally.
             // Scripts should exist on the remote at this point.
@@ -806,7 +807,7 @@ impl ExperimentRunner {
             session::run_script_at(
                 &setup_sessions,
                 remote_script,
-                variation_directory,
+                &variation_directory,
             )
             .await?;
             // TODO(joren): Handle error case
@@ -818,28 +819,68 @@ impl ExperimentRunner {
         Ok(())
     }
 
+    async fn make_configuration_directories(&self) -> session::Result<()> {
+        session::make_directories(
+            &*self.current.sessions.read().await,
+            &self.configuration.directories(),
+        )
+        .await
+    }
+    async fn make_variation_directory(&self) -> session::Result<()> {
+        session::make_directory(
+            &*self.current.sessions.read().await,
+            &self.variation_directory().await,
+        )
+        .await
+    }
+
+    async fn upload_files_for_experiments(
+        &self,
+        experiments: &[Experiment],
+    ) -> session::Result<()> {
+        let files = unique_files_for_experiments(experiments);
+        session::upload(
+            &*self.current.sessions.read().await,
+            &files,
+            &self.experiment_directory().await,
+        )
+        .await
+    }
+
+    async fn connect_to_hosts(
+        &self,
+        experiments: &[Experiment],
+    ) -> session::Result<()> {
+        let hosts = unique_hosts_for_experiments(experiments);
+        let sessions = session::connect_to_hosts(&hosts).await?;
+        *self.current.sessions.write().await = sessions;
+        Ok(())
+    }
+
     async fn symlink_dependencies(
-        sessions: &Sessions,
+        &self,
         remote_execution: &RemoteExecution,
         dependencies: &[PathBuf],
-        experiment_directory: &Path,
-        variation_directory: &Path,
     ) -> Result<Vec<ExecutionResult>> {
         let filter_sessions =
-            Self::filter_host_sessions(sessions, &remote_execution.hosts);
+            self.filter_host_sessions(&remote_execution.hosts).await;
 
         let script = match &remote_execution.command {
             CommandSource::Script(script) => script,
             CommandSource::Command(_) => return Ok(vec![]),
         };
 
-        let deps_path = file_to_deps_path(experiment_directory, script);
+        let deps_path =
+            file_to_deps_path(&self.experiment_directory().await, script);
 
         let command_args: Vec<String> = [
             "ln".to_string(),
             "-s".to_string(),
             "-t".to_string(),
-            variation_directory.to_string_lossy().to_string(),
+            self.variation_directory()
+                .await
+                .to_string_lossy()
+                .to_string(),
         ]
         .into_iter()
         .chain(dependencies.iter().map(|dep| {
@@ -861,13 +902,14 @@ impl ExperimentRunner {
     }
 
     async fn unlink_dependencies(
-        sessions: &Sessions,
+        &self,
         remote_execution: &RemoteExecution,
         dependencies: &[PathBuf],
-        variation_directory: &Path,
     ) -> Result<()> {
         let filter_sessions =
-            Self::filter_host_sessions(sessions, &remote_execution.hosts);
+            self.filter_host_sessions(&remote_execution.hosts).await;
+
+        let variation_directory = self.variation_directory().await;
 
         let args: Vec<String> = dependencies
             .iter()
@@ -891,13 +933,14 @@ impl ExperimentRunner {
         // .map_err(Error::from)
     }
 
-    async fn collect_results(
-        sessions: &Sessions,
-        variation_directory: &Path,
-        results_dir: &Path,
-    ) -> Result<()> {
+    async fn collect_results(&self, results_dir: &Path) -> Result<()> {
+        let variation_directory = self.variation_directory().await;
+
+        //TODO(joren): We can just store the timestamp in the ExperimentRunnerCurrent struct so we
+        //don't even need this function anymore.
+
         let (experiment_name, run, ts) =
-            variation_dir_parts(variation_directory);
+            variation_dir_parts(&variation_directory);
 
         info!(
             "Collecting results for experiment '{}' (repeat {})",
@@ -914,15 +957,269 @@ impl ExperimentRunner {
             ))
         })?;
 
-        session::download(sessions, &[variation_directory], &local_results_dir)
-            .await?;
+        session::download(
+            &*self.current.sessions.read().await,
+            &[variation_directory],
+            local_results_dir,
+        )
+        .await?;
 
         Ok(())
     }
+
+    pub async fn tail_stdout_stderr(
+        &self,
+        thing: crate::routes::Thing,
+    ) -> Result<(UnboundedReceiver<Message>, UnboundedReceiver<Message>)> {
+        let sessions = self.filter_sessions(&[thing.host]).await;
+
+        // We need to make sure that our exporter/setup/teardown/execute is running
+        if thing.filetype == FileType::Exporter {
+            match self.current.exporters.read().await.get(&thing.identifier) {
+                Some(handle) => dbg!(handle),
+                None => {
+                    return Err(Error::FollowError(format!(
+                        "The exporter {} is not running",
+                        thing.identifier
+                    )))
+                }
+            };
+        }
+
+        let stdout = format!("{}.stdout", thing.identifier);
+        let stderr = format!("{}.stderr", thing.identifier);
+
+        let mut stdout_shell_command = ShellCommand::from_command("tail");
+        stdout_shell_command
+            .args(&[
+                "-c".to_string(),
+                "+0".to_string(),
+                "-f".to_string(),
+                stdout,
+            ])
+            .working_directory(self.configuration.live_dir(&thing.filetype));
+
+        let mut stderr_shell_command = ShellCommand::from_command("tail");
+        stderr_shell_command
+            .args(&[
+                "-c".to_string(),
+                "+0".to_string(),
+                "-f".to_string(),
+                stderr,
+            ])
+            .working_directory(self.configuration.live_dir(&thing.filetype));
+
+        let stdout_handle = command::run_command(
+            &sessions,
+            stdout_shell_command,
+            ExecutionType::Spawn,
+        )
+        .await?;
+
+        let stdout_handle = stdout_handle
+            .into_iter()
+            .map(|stdout_thread| {
+                if let ExecutionResult::Spawn(child) = stdout_thread {
+                    child
+                } else {
+                    // Since we specified ExecutionType::Spawn, we should definitely be getting
+                    // ExecutionResult::Spawn back from this function
+                    panic!();
+                }
+            })
+            .collect::<Vec<SpawnType>>()
+            .pop()
+            .expect("We should have had a process at this point");
+
+        let (stdout_sender, stdout_recv) =
+            tokio::sync::mpsc::unbounded_channel::<Message>();
+
+        match stdout_handle {
+            SpawnType::SSH(mut child) => tokio::spawn(async move {
+                let mut stdout = child.stdout().take().unwrap();
+                let mut buf = [0; 100];
+                loop {
+                    let n = stdout.read(&mut buf).await?;
+                    if n == 0 {
+                        return Ok::<(), Error>(());
+                    }
+                    let message =
+                        Message::text(String::from_utf8(buf.to_vec()).unwrap());
+                    match stdout_sender.send(message) {
+                        Ok(()) => {}
+                        Err(_e) => return Ok::<(), Error>(()),
+                    }
+                }
+            }),
+            SpawnType::Tokio(child) => tokio::spawn(async move {
+                let mut stdout = child.stdout.unwrap();
+                let mut buf = [0; 100];
+                loop {
+                    let n = stdout.read(&mut buf).await?;
+                    if n == 0 {
+                        return Ok(());
+                    }
+                    let message =
+                        Message::text(String::from_utf8(buf.to_vec()).unwrap());
+                    match stdout_sender.send(message) {
+                        Ok(()) => {}
+                        Err(_e) => return Ok::<(), Error>(()),
+                    }
+                }
+            }),
+        };
+
+        let stderr_handle = command::run_command(
+            &sessions,
+            stderr_shell_command,
+            ExecutionType::Spawn,
+        )
+        .await?;
+
+        let stderr_handle = stderr_handle
+            .into_iter()
+            .map(|stderr_thread| {
+                if let ExecutionResult::Spawn(child) = stderr_thread {
+                    child
+                } else {
+                    // Since we specified ExecutionType::Spawn, we should definitely be getting
+                    // ExecutionResult::Spawn back from this function
+                    panic!();
+                }
+            })
+            .collect::<Vec<SpawnType>>()
+            .pop()
+            .expect("We should have had a process at this point");
+
+        let (stderr_sender, stderr_recv) =
+            tokio::sync::mpsc::unbounded_channel::<Message>();
+
+        match stderr_handle {
+            SpawnType::SSH(mut child) => tokio::spawn(async move {
+                // Yes, the stderr is returned from stdout
+                let mut stderr = child.stdout().take().unwrap();
+                let mut buf = [0; 100];
+                loop {
+                    let n = stderr.read(&mut buf).await?;
+                    if n == 0 {
+                        return Ok::<(), Error>(());
+                    }
+                    let message =
+                        Message::text(String::from_utf8(buf.to_vec()).unwrap());
+                    match stderr_sender.send(message) {
+                        Ok(()) => {}
+                        Err(_e) => return Ok::<(), Error>(()),
+                    }
+                }
+            }),
+            SpawnType::Tokio(child) => tokio::spawn(async move {
+                let mut stderr = child.stdout.unwrap();
+                let mut buf = [0; 100];
+                loop {
+                    let n = stderr.read(&mut buf).await?;
+                    if n == 0 {
+                        return Ok(());
+                    }
+                    let message =
+                        Message::text(String::from_utf8(buf.to_vec()).unwrap());
+                    match stderr_sender.send(message) {
+                        Ok(()) => {}
+                        Err(_e) => return Ok::<(), Error>(()),
+                    }
+                }
+            }),
+        };
+
+        Ok((stdout_recv, stderr_recv))
+    }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     #[test]
-//     fn enqueue_experiment() {}
-// }
+impl Default for ExperimentRunner {
+    fn default() -> Self {
+        let current: ExperimentRunnerCurrent = Default::default();
+        let configuration: ExperimentRunnerConfiguration = Default::default();
+        let experiment_queue =
+            Mutex::new(VecDeque::with_capacity(configuration.max_experiments));
+
+        Self {
+            current,
+            configuration,
+            experiment_queue,
+        }
+    }
+}
+
+/// Loops through a slice of experiments and returns
+/// unique filepaths for that slice.
+fn unique_files_for_experiments(experiments: &[Experiment]) -> Vec<&Path> {
+    let mut files: Vec<&Path> = experiments
+        .iter()
+        .flat_map(|experiment| experiment.files())
+        .collect();
+
+    files.sort();
+    files.dedup();
+    files
+}
+
+/// Retrieves all the unique hosts used across a list of experiments.
+/// This is useful for performing pre-run and post-run actions on these
+/// hosts that are necessary for experimentah to function correctly.
+/// These hosts should be filtered as required by each individual experiment variation.
+fn unique_hosts_for_experiments(experiments: &[Experiment]) -> Vec<&String> {
+    let mut hosts: Vec<&String> = experiments
+        .iter()
+        .flat_map(|experiment| experiment.hosts())
+        .collect();
+
+    hosts.sort();
+    hosts.dedup();
+    hosts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn runner() -> ExperimentRunner {
+        let runner = ExperimentRunner::new();
+
+        let ts = time_since_epoch()
+            .expect("We shouldn't be failing to get time")
+            .as_millis();
+        let experiment_name = String::from("test_experiment_name");
+        let run: u16 = 1;
+        let runs: u16 = 10;
+        let sessions = Sessions::default();
+        let exporters = ExportersHandles::default();
+
+        *runner.current.ts.lock().await = ts;
+        *runner.current.experiment_name.lock().await = Some(experiment_name);
+        runner.current.run.store(run, Ordering::Relaxed);
+        runner.current.runs.store(runs, Ordering::Relaxed);
+        *runner.current.sessions.write().await = sessions;
+        *runner.current.exporters.write().await = exporters;
+
+        runner
+    }
+
+    #[tokio::test]
+    async fn runner_reset() {
+        let runner = runner().await;
+        runner.current.reset().await;
+
+        let ts = runner.current.ts.lock().await;
+        let experiment_name = runner.current.experiment_name.lock().await;
+        let run: u16 = runner.current.run.load(Ordering::Relaxed);
+        let runs: u16 = runner.current.runs.load(Ordering::Relaxed);
+        let sessions = runner.current.sessions.read().await;
+        let exporters = runner.current.exporters.read().await;
+
+        assert_eq!(*ts, 0);
+        assert_eq!(*experiment_name, None);
+        assert_eq!(run, 0);
+        assert_eq!(runs, 0);
+        assert!(sessions.is_empty());
+        assert!(exporters.is_empty());
+    }
+}

--- a/controller/tests/configs/experiment_config_valid.toml
+++ b/controller/tests/configs/experiment_config_valid.toml
@@ -36,6 +36,8 @@ variations_only = false
 
 # Optional: A list of setup instructions to run across different hosts
 [[setups]]
+# Required: The name for this setup
+name = "main-setup"
 # Required: The hosts to perform this setup on
 hosts = ["test-runner"]
 # The below options "script" and "command" are mutually exclusive, but one must be run.
@@ -52,6 +54,8 @@ dependencies = ["setup-dependency.sh"]
 
 # Optional: A list of teardown instructions to run across different hosts
 [[teardowns]]
+# Required: the name for this teardown
+name = "main-teardown"
 hosts = ["test-runner"]
 # The below options "script" and "command" are mutually exclusive, but one must be run.
 # The script to perform setup on this host


### PR DESCRIPTION
Debugging is a large part of the process when running experiments on remote machines. You need to know when something fails, and how it fails.

The problem is, when running experiments, you generally don't want to be streaming information over the network (a slow process) unless you're in the middle of one of these debug cycles. As such, the ability to stream output from any command run under Experimentah is required. This means that we need to write the stdout/stderr of our processes to files on remote machines, and and a websocket should tail the output of the stdout/stderr file, presenting it to the client.

This branch adds a new route "/ws", and modifies existing configuration data structures with additional required information so that a user can specify what program they want to follow.